### PR TITLE
Fix usage of undefined variable 'dest' for 'UP'

### DIFF
--- a/src/main/groovy/com/monochromeroad/gradle/plugin/aws/s3/S3Sync.groovy
+++ b/src/main/groovy/com/monochromeroad/gradle/plugin/aws/s3/S3Sync.groovy
@@ -98,7 +98,7 @@ class S3Sync extends DefaultTask {
         }
         else if (action == 'DOWN'){
             project.file(destination).mkdirs()
-            dest = [new File(destination)]
+            def dest = [new File(destination)]
             client.run(originalSourcePath, dest,
                         action,
                         properties.getStringProperty("password", null), aclString,


### PR DESCRIPTION
variable 'dest' is used, though undefined.

Execution failed for task ':XXX'.
23:10:19.609 [ERROR] [org.gradle.BuildExceptionReporter] > No such property: dest for class: com.monochromeroad.gradle.plugin.aws.s3.S3Sync_Decorated
