### PR TITLE
Update JetS3t to 0.9.3.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ import groovyx.net.http.HTTPBuilder
 import static groovyx.net.http.ContentType.*
 import static groovyx.net.http.Method.*
 
-version = "0.8"
+version = "0.8.1"
 group = "com.monochromeroad.gradle-plugins"
 
 repositories {
@@ -21,7 +21,7 @@ repositories {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile "net.java.dev.jets3t:jets3t:0.9.2"
+    compile "net.java.dev.jets3t:jets3t:0.9.3"
     testCompile "org.spockframework:spock-core:1.0-groovy-2.3-SNAPSHOT"
 }
 


### PR DESCRIPTION
Hi, I suggest upgrading to JetS3t 0.9.3. Personally I need the "support [for] Amazon signature version 4 (AWS4-HMAC-SHA256) when signing requests, in particular to permit access to version-4-only region eu-central-1" (see http://www.jets3t.org/RELEASE_NOTES.html).