### PR TITLE
Use jets3t 0.9.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ import groovyx.net.http.HTTPBuilder
 import static groovyx.net.http.ContentType.*
 import static groovyx.net.http.Method.*
 
-version = "0.9"
+version = "0.9.1"
 group = "com.monochromeroad.gradle-plugins"
 
 repositories {
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile "net.java.dev.jets3t:jets3t:0.9.3"
+    compile "net.java.dev.jets3t:jets3t:0.9.4"
     testCompile "org.spockframework:spock-core:1.0-groovy-2.3"
 }
 


### PR DESCRIPTION
From http://www.jets3t.org/RELEASE_NOTES.html jets3t fixed some bugs with API version 4.