### PR TITLE
Build artifacts compatible with Java 1.6+.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 dependencies {
     compile gradleApi()
     compile "net.java.dev.jets3t:jets3t:0.9.3"
-    testCompile("org.spockframework:spock-core:1.0-groovy-2.4") {
+    testCompile("org.spockframework:spock-core:1.0-groovy-2.3") {
         exclude group: 'org.codehaus.groovy'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,9 @@ import groovyx.net.http.HTTPBuilder
 import static groovyx.net.http.ContentType.*
 import static groovyx.net.http.Method.*
 
-version = "0.9"
+version = "0.10-SNAPSHOT"
 group = "com.monochromeroad.gradle-plugins"
+targetCompatibility = 1.6
 
 repositories {
     jcenter()
@@ -21,7 +22,9 @@ repositories {
 dependencies {
     compile gradleApi()
     compile "net.java.dev.jets3t:jets3t:0.9.3"
-    testCompile "org.spockframework:spock-core:1.0-groovy-2.3"
+    testCompile("org.spockframework:spock-core:1.0-groovy-2.4") {
+        exclude group: 'org.codehaus.groovy'
+    }
 }
 
 groovydoc {


### PR DESCRIPTION
* Set targetCompatibility = 1.6
* Excluded org.codehaus.groovy from test compile classpath. The groovy
  dependencies are already provided by the gradle runtime environment.
* Updated the spock dependency to target Groovy 2.4

Fixes issue #19 